### PR TITLE
Fix line that should check for half day off in the overtime calculation

### DIFF
--- a/models/hr_timesheet_sheet.py
+++ b/models/hr_timesheet_sheet.py
@@ -241,7 +241,7 @@ class Sheet(models.Model):
                 duty_hours += dh
             else:
                 if leaves[-1] and leaves[-1][-1]:
-                    if float(leaves[-1][-1]) == (-0.5):
+                    if float(leaves[-1][-1]) == (0.5):
                         duty_hours += dh / 2
         return duty_hours
 


### PR DESCRIPTION
Duty hours for a working day should be reduced with 50% in case of approved half day off. The check must be done on 0.5 not -0.5