### PR TITLE
Add a project setting to exclude reported hours from printed timesheets

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -21,3 +21,4 @@
 
 from . import hr_timesheet_sheet
 from . import resource_calendar
+from . import project

--- a/models/hr_timesheet_sheet.py
+++ b/models/hr_timesheet_sheet.py
@@ -92,8 +92,6 @@ class Sheet(models.Model):
                            type="text",
                            string="Attendance Analysis")
 
-    overtime_payment_time = fields.Float(compute="_compute_overtime_payment_time", string="Overtime payment time", store=True)
-
 
     @api.depends("timesheet_ids.unit_amount")
     def _compute_total_time(self):
@@ -102,22 +100,10 @@ class Sheet(models.Model):
 
             total_time = 0
             for aal in sheet.timesheet_ids:
-                if aal.project_id.name.lower().strip() != 'overtime payment':
-                    total_time += aal.unit_amount
+                total_time += aal.unit_amount
 
             sheet.total_time = total_time
 
-
-    @api.depends("timesheet_ids.unit_amount")
-    def _compute_overtime_payment_time(self):
-        for sheet in self:
-
-            overtime_payment_time = 0
-            for aal in sheet.timesheet_ids:
-                if aal.project_id.name.lower().strip() == 'overtime payment':
-                    overtime_payment_time += aal.unit_amount
-
-            sheet.overtime_payment_time = overtime_payment_time
 
     def _duty_hours(self):
         _logger.info("_duty_hours")
@@ -174,7 +160,7 @@ class Sheet(models.Model):
     def get_overtime(self, start_date):
         _logger.info("get_overtime")
         for sheet in self:
-            return sheet.total_time - sheet.total_duty_hours_done + sheet.overtime_payment_time
+            return sheet.total_time - sheet.total_duty_hours_done
 
 
     def _prev_timesheet_diff(self):

--- a/models/project.py
+++ b/models/project.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models
+
+
+
+
+class Project(models.Model):
+    _inherit = 'project.project'
+
+    excl_from_printed_timesheets = fields.Boolean("Exclude from printed timesheets")
+
+

--- a/views/views.xml
+++ b/views/views.xml
@@ -8,7 +8,8 @@
             <xpath expr="/form/sheet/group/group[@name='dates']" position="after">
                 <group>
                     <field name="total_duty_hours" widget="float_time" string="Expected this timesheet"/>
-                    <field name="total_time" widget="float_time"/>
+                    <field name="total_time" widget="float_time" string="Total time"/>
+                    <field name="overtime_payment_time" widget="float_time" attrs="{'invisible':[('overtime_payment_time', '=', 0)]}"/>
                     <field name="prev_timesheet_diff" widget="float_time" string="Previous balance"/>
                     <field name="calculate_diff_hours" widget="float_time" string="Total balance"/>
                 </group>

--- a/views/views.xml
+++ b/views/views.xml
@@ -9,7 +9,6 @@
                 <group>
                     <field name="total_duty_hours" widget="float_time" string="Expected this timesheet"/>
                     <field name="total_time" widget="float_time" string="Total time"/>
-                    <field name="overtime_payment_time" widget="float_time" attrs="{'invisible':[('overtime_payment_time', '=', 0)]}"/>
                     <field name="prev_timesheet_diff" widget="float_time" string="Previous balance"/>
                     <field name="calculate_diff_hours" widget="float_time" string="Total balance"/>
                 </group>
@@ -21,4 +20,33 @@
             </notebook>
         </field>
     </record>
+
+
+    <record id="project_excl_from_printed_timesheets_form" model="ir.ui.view">
+        <field name="name">Add field excl_from_printed_timesheets</field>
+        <field name="model">project.project</field>
+        <field name="inherit_id" ref="project.edit_project"/>
+        <field name="priority">24</field>
+        <field name="arch" type="xml">
+
+            <xpath expr="//div[@id='rating_settings']/.." position="before">
+                <div class="row mt16 o_settings_container">
+                    <div class="col-lg-6 o_setting_box"  id="timesheet_settings_excl_pr_timesh">
+                        <div class="o_setting_left_pane">
+                            <field name="excl_from_printed_timesheets"/>
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="excl_from_printed_timesheets" string="Exclude from printed timesheets"/>
+                            <div class="text-muted">
+                                Time written on this project will not be shown on the timesheet report
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+
+        </field>
+    </record>
+
+
 </odoo>


### PR DESCRIPTION
It should be shown below the Total time field.

Total time should show the sum of all real hours that the employee has worked (and registered) for this timesheet period.

The field Overtime payment time shows the sum of all hours written on the project Overtime payment. Normally, we expect hours on this project to be written not more than one time. Furthermore we expect a negative amount (allthough this is not checked).

The field is not shown if there aren't any hours written on the project Overtime payment.