### PR TITLE
fix flexitime balance miscalculations

### DIFF
--- a/models/hr_timesheet_sheet.py
+++ b/models/hr_timesheet_sheet.py
@@ -142,14 +142,14 @@ class Sheet(models.Model):
                         (leave_date_start, leave_date_end, leave.number_of_days))
                     break
         return leaves
-    
-    
+
+
     def get_overtime(self, start_date):
         _logger.info("get_overtime")
         for sheet in self:
-            return sheet.total_time - sheet.total_duty_hours_done
-    
-    
+            return sheet.total_time - sheet.total_duty_hours
+
+
     def _prev_timesheet_diff(self):
         _logger.info("_prev_timesheet_diff")
         for sheet in self:
@@ -165,9 +165,9 @@ class Sheet(models.Model):
             sheet.prev_timesheet_diff = prev_timesheet_diff
         _logger.info("_prev_timesheet_diff")
 
-    
+
     # Pupulate Overtime Analysis table data with results from attendance_analysis
-    
+
     def _get_analysis(self):
         res = {}
         _logger.info("_get_analysis")
@@ -214,8 +214,8 @@ class Sheet(models.Model):
             output.append('</table>')
             sheet['analysis'] = '\n'.join(output)
         _logger.info("_get_analysis_end")
-    
-    
+
+
     def calculate_duty_hours(self, date_start, period):
         contract_obj = self.env['hr.contract']
         calendar_obj = self.env['resource.calendar']
@@ -292,8 +292,8 @@ class Sheet(models.Model):
             date_format = lang.date_format
             time_format = lang.time_format
         return date_format, time_format
-    
-    
+
+
     def attendance_analysis(self, timesheet_id=None, function_call=False):
         date_format, time_format = self._get_user_datetime_format()
         for sheet in self:
@@ -308,7 +308,7 @@ class Sheet(models.Model):
                     'previous_month_diff': previous_month_diff,
                     'hours': []
                 }
-    
+
                 period = {'date_start': start_date,
                           'date_end': end_date
                           }
@@ -325,7 +325,7 @@ class Sheet(models.Model):
                          'diff':
                              current_month_diff, 'work_current_month_diff': 0.0}
                 for date_line in dates:
-    
+
                     dh = sheet.calculate_duty_hours(date_start=date_line,
                                                     period=period,
                                                     )
@@ -333,7 +333,7 @@ class Sheet(models.Model):
                     for att in sheet.timesheet_ids:
                         if att.date == date_line.date():
                             worked_hours += att.unit_amount
-    
+
                     diff = worked_hours - dh
                     current_month_diff += diff
                     work_current_month_diff += diff


### PR DESCRIPTION
total_duty_hours_done is not being computed, total_duty_hours is. When the timesheet is still open that is the field we want to use, so the actual value is always computed. Important changes that require recomputing: time off requests of user U AFTER creation of timesheet T for same user U